### PR TITLE
uintptr_t is defined in <stdint.h>

### DIFF
--- a/include/mqtt_pal.h
+++ b/include/mqtt_pal.h
@@ -70,6 +70,7 @@ extern "C" {
 
 /* UNIX-like platform support */
 #if defined(__unix__) || defined(__APPLE__)
+    #include <stdint.h>
     #include <limits.h>
     #include <string.h>
     #include <stdarg.h>


### PR DESCRIPTION
Fixes:

> note: 'uintptr_t' is defined in header '<stdint.h>';
> did you forget to '#include <stdint.h>'?